### PR TITLE
fixed version of scipy in requirements.txt

### DIFF
--- a/webserver/requirements.txt
+++ b/webserver/requirements.txt
@@ -9,3 +9,4 @@ conllu
 gensim
 requests
 bs4
+scipy==1.12.0


### PR DESCRIPTION
When we do `docker-compose up` , it breaks with the following errors

![image](https://github.com/TeangaNLP/cardamom-workbench/assets/13376173/87dc195f-34d2-40fd-8995-5460057dad13)

This issue is caused by the new version of **scipy** (v1.13.0) which gets installed as its a dependency of **gensim**

One fix is to add the specific version of scipy v.1.12.0 (https://pypi.org/project/scipy/#history) which worked well previously. 

(In order to test, make sure you remove previous docker images)
